### PR TITLE
send teleport events when using spawn and warp

### DIFF
--- a/Core/src/main/java/su/nightexpress/sunlight/module/spawns/event/PlayerSpawnTeleportEvent.java
+++ b/Core/src/main/java/su/nightexpress/sunlight/module/spawns/event/PlayerSpawnTeleportEvent.java
@@ -1,0 +1,54 @@
+package su.nightexpress.sunlight.module.spawns.event;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+import su.nightexpress.sunlight.module.spawns.impl.Spawn;
+import su.nightexpress.sunlight.module.warps.impl.Warp;
+
+public class PlayerSpawnTeleportEvent extends Event implements Cancellable {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private final Player player;
+    private final Spawn spawn;
+
+    private boolean cancelled;
+
+    public PlayerSpawnTeleportEvent(@NotNull Player player, @NotNull Spawn spawn) {
+        this.player = player;
+        this.spawn = spawn;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    @NotNull
+    public Player getPlayer() {
+        return player;
+    }
+
+    @NotNull
+    public Spawn getSpawn() {
+        return spawn;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+}

--- a/Core/src/main/java/su/nightexpress/sunlight/module/spawns/impl/Spawn.java
+++ b/Core/src/main/java/su/nightexpress/sunlight/module/spawns/impl/Spawn.java
@@ -16,6 +16,7 @@ import su.nightexpress.sunlight.config.Lang;
 import su.nightexpress.sunlight.module.spawns.SpawnsModule;
 import su.nightexpress.sunlight.module.spawns.config.SpawnsLang;
 import su.nightexpress.sunlight.module.spawns.editor.SpawnSettingsEditor;
+import su.nightexpress.sunlight.module.spawns.event.PlayerSpawnTeleportEvent;
 import su.nightexpress.sunlight.module.spawns.util.Placeholders;
 import su.nightexpress.sunlight.module.spawns.util.SpawnsPerms;
 
@@ -134,6 +135,12 @@ public class Spawn extends AbstractConfigHolder<SunLight> implements Placeholder
     }
 
     public boolean teleport(@NotNull Player player, boolean isForce) {
+        if (!isForce) {
+            PlayerSpawnTeleportEvent event = new PlayerSpawnTeleportEvent(player, this);
+            plugin.getPluginManager().callEvent(event);
+            if (event.isCancelled()) return false;
+        }
+
         if (!isForce && !this.hasPermission(player)) {
             plugin.getMessage(Lang.ERROR_PERMISSION_DENY).send(player);
             return false;

--- a/Core/src/main/java/su/nightexpress/sunlight/module/warps/event/PlayerWarpTeleportEvent.java
+++ b/Core/src/main/java/su/nightexpress/sunlight/module/warps/event/PlayerWarpTeleportEvent.java
@@ -1,0 +1,54 @@
+package su.nightexpress.sunlight.module.warps.event;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+import su.nightexpress.sunlight.module.homes.impl.Home;
+import su.nightexpress.sunlight.module.warps.impl.Warp;
+
+public class PlayerWarpTeleportEvent extends Event implements Cancellable {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private final Player player;
+    private final Warp warp;
+
+    private boolean cancelled;
+
+    public PlayerWarpTeleportEvent(@NotNull Player player, @NotNull Warp warp) {
+        this.player = player;
+        this.warp = warp;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    @NotNull
+    public Player getPlayer() {
+        return player;
+    }
+
+    @NotNull
+    public Warp getWarp() {
+        return warp;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+}

--- a/Core/src/main/java/su/nightexpress/sunlight/module/warps/impl/Warp.java
+++ b/Core/src/main/java/su/nightexpress/sunlight/module/warps/impl/Warp.java
@@ -21,6 +21,7 @@ import su.nightexpress.sunlight.data.impl.cooldown.CooldownInfo;
 import su.nightexpress.sunlight.module.warps.WarpsModule;
 import su.nightexpress.sunlight.module.warps.command.WarpShortcutCommand;
 import su.nightexpress.sunlight.module.warps.config.WarpsLang;
+import su.nightexpress.sunlight.module.warps.event.PlayerWarpTeleportEvent;
 import su.nightexpress.sunlight.module.warps.menu.WarpSettingsMenu;
 import su.nightexpress.sunlight.module.warps.type.WarpType;
 import su.nightexpress.sunlight.module.warps.util.Placeholders;
@@ -172,6 +173,12 @@ public class Warp extends AbstractConfigHolder<SunLight> implements Placeholder 
     }
 
     public void teleport(@NotNull Player player, boolean isForced) {
+        if (!isForced) {
+            PlayerWarpTeleportEvent event = new PlayerWarpTeleportEvent(player, this);
+            this.plugin.getPluginManager().callEvent(event);
+            if (event.isCancelled()) return;
+        }
+
         if (!isForced && !this.hasPermission(player)) {
             this.plugin.getMessage(WarpsLang.WARP_TELEPORT_ERROR_NO_PERMISSION).replace(this.replacePlaceholders()).send(player);
             return;


### PR DESCRIPTION
This is necessary so that other plugins can control teleportation to warp/spawn