### PR TITLE
Added sunlight /kill command

### DIFF
--- a/Core/src/main/java/su/nightexpress/sunlight/Perms.java
+++ b/Core/src/main/java/su/nightexpress/sunlight/Perms.java
@@ -156,6 +156,9 @@ public class Perms {
     public static final JPermission COMMAND_ITEM_SPAWN       = forCommand(ItemCommand.NAME, ItemSpawnCommand.NAME);
     public static final JPermission COMMAND_ITEM_POTION      = forCommand(ItemCommand.NAME, ItemPotionCommand.NAME);
 
+    public static final JPermission COMMAND_KILL       = forCommand(KillCommand.NAME);
+    public static final JPermission COMMAND_KILL_OTHERS       = forCommandOthers(KillCommand.NAME);
+
     public static final JPermission COMMAND_LOOM = forCommand(LoomCommand.NAME);
     public static final JPermission COMMAND_LOOM_OTHERS = forCommandOthers(LoomCommand.NAME);
 
@@ -282,6 +285,8 @@ public class Perms {
             COMMAND_ITEM_GET, COMMAND_ITEM_GIVE, COMMAND_ITEM_LORE, COMMAND_ITEM_MODEL,
             COMMAND_ITEM_NAME, COMMAND_ITEM_SPAWN, COMMAND_ITEM_TAKE, COMMAND_ITEM_POTION,
             COMMAND_ITEM_DAMAGE, COMMAND_ITEM_UNBREAKABLE,
+
+            COMMAND_KILL, COMMAND_KILL_OTHERS,
 
             COMMAND_LOOM, COMMAND_LOOM_OTHERS,
 

--- a/Core/src/main/java/su/nightexpress/sunlight/command/CommandRegulator.java
+++ b/Core/src/main/java/su/nightexpress/sunlight/command/CommandRegulator.java
@@ -70,6 +70,7 @@ public class CommandRegulator extends AbstractManager<SunLight> {
         this.register(InventoryCommand.NAME, (cfg, aliases) -> new InventoryCommand(plugin, aliases), "inv");
         this.register(ItemCommand.NAME, (cfg, aliases) -> new ItemCommand(plugin, cfg, aliases), "i");
         this.register(LoomCommand.NAME, (cfg, aliases) -> new LoomCommand(plugin, aliases));
+        this.register(KillCommand.NAME, (cfg, aliases) -> new KillCommand(plugin, aliases));
         this.register(MobCommand.NAME, (cfg, aliases) -> new MobCommand(plugin, aliases));
         this.register(NearCommand.NAME, (cfg, aliases) -> new NearCommand(plugin, cfg, aliases));
         this.register(NickCommand.NAME, (cfg, aliases) -> new NickCommand(plugin, cfg, aliases));

--- a/Core/src/main/java/su/nightexpress/sunlight/command/list/KillCommand.java
+++ b/Core/src/main/java/su/nightexpress/sunlight/command/list/KillCommand.java
@@ -1,0 +1,45 @@
+package su.nightexpress.sunlight.command.list;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import su.nexmedia.engine.api.command.CommandResult;
+import su.nexmedia.engine.utils.Placeholders;
+import su.nightexpress.sunlight.Perms;
+import su.nightexpress.sunlight.SunLight;
+import su.nightexpress.sunlight.command.CommandFlags;
+import su.nightexpress.sunlight.command.api.TargetCommand;
+import su.nightexpress.sunlight.config.Lang;
+
+public class KillCommand extends TargetCommand {
+
+    public static final String NAME = "kill";
+
+    public KillCommand(@NotNull SunLight plugin, @NotNull String[] aliases) {
+        super(plugin, aliases, Perms.COMMAND_KILL, Perms.COMMAND_KILL_OTHERS, 0);
+        this.setAllowDataLoad();
+        this.setDescription(plugin.getMessage(Lang.COMMAND_KILL_DESC));
+        this.setUsage(plugin.getMessage(Lang.COMMAND_KILL_USAGE));
+        this.addFlag(CommandFlags.SILENT);
+    }
+
+    @Override
+    protected void onExecute(@NotNull CommandSender sender, @NotNull CommandResult result) {
+        Player target = this.getCommandTarget(sender, result);
+        if (target == null) return;
+
+        target.setHealth(0);
+        if (!target.isOnline()) target.saveData();
+
+        if (sender != target) {
+            plugin.getMessage(Lang.COMMAND_KILL_TARGET)
+                .replace(Placeholders.forPlayer(target))
+                .send(sender);
+        }
+        if (!result.hasFlag(CommandFlags.SILENT)) {
+            plugin.getMessage(Lang.COMMAND_KILL_NOTIFY)
+                .replace(Placeholders.forPlayer((Player) sender))
+                .send(target);
+        }
+    }
+}

--- a/Core/src/main/java/su/nightexpress/sunlight/config/Lang.java
+++ b/Core/src/main/java/su/nightexpress/sunlight/config/Lang.java
@@ -343,6 +343,11 @@ public class Lang extends EngineLang {
     public static final LangKey COMMAND_ITEM_UNBREAKABLE_DONE           = LangKey.of("Command.Item.Unbreakable.Done", "<! sound:\"" + Sound.BLOCK_ANVIL_USE.name() + "\" !>" + LIGHT_YELLOW + "Set " + ORANGE + Placeholders.GENERIC_ITEM + LIGHT_YELLOW + " Unbreakable: " + ORANGE + Placeholders.GENERIC_STATE + LIGHT_YELLOW + ".");
     public static final LangKey COMMAND_ITEM_UNBREAKABLE_ERROR_BAD_ITEM = LangKey.of("Command.Item.Unbreakable.Error.NotDamageable", "<! sound:\"" + Sound.ENTITY_VILLAGER_NO.name() + "\" !>" + ORANGE + Placeholders.GENERIC_ITEM + RED + " can not be (un)breakable.");
 
+    public static final LangKey COMMAND_KILL_DESC   = LangKey.of("Command.Kill.Desc", "Kill [player].");
+    public static final LangKey COMMAND_KILL_USAGE  = LangKey.of("Command.Kill.Usage", "[player] [-s]");
+    public static final LangKey COMMAND_KILL_NOTIFY = LangKey.of("Command.Kill.Done.Self", LIGHT_YELLOW + "You got killed by " + ORANGE + Placeholders.PLAYER_DISPLAY_NAME + LIGHT_YELLOW + "!");
+    public static final LangKey COMMAND_KILL_TARGET = LangKey.of("Command.Kill.Done.Others", LIGHT_YELLOW + "Killed " + ORANGE + Placeholders.PLAYER_DISPLAY_NAME + LIGHT_YELLOW + "!");
+
     public static final LangKey COMMAND_LOOM_DESC   = LangKey.of("Command.Loom.Desc", "Open portable loom.");
     public static final LangKey COMMAND_LOOM_USAGE  = LangKey.of("Command.Loom.Usage", "[player] [-s]");
     public static final LangKey COMMAND_LOOM_NOTIFY = LangKey.of("Command.Loom.Notify", ACTION_BAR + LIGHT_YELLOW + "You opened loom.");


### PR DESCRIPTION
There's no kill command in sunlight, and i thought, that it would be nice to add it.

Added /kill command, kill and kill.others permissions and Command.Kill.[Target, Notify, Usage, Description] strings